### PR TITLE
Parallelize MatchRunner

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Plays the host bot against all the others on all the maps
   -l, --elo         Calculates the elo for the run
   -m, --all-maps    Runs all teams specified on all maps in maps/
   -o, --host        Specify a host for the tournament for VsWorld
+  -p, --processes   Specify the number of simultaneous processes used to run matches
   -r, --replay-dir  Specify the directory to save the replays in    [default: "replays"]
   -s, --series      Players play the maps in series instead 1 by 1
   -t, --all-teams   Runs all teams in src/ on the specified maps

--- a/lib/game.js
+++ b/lib/game.js
@@ -2,6 +2,7 @@ var spawn = require('child_process').spawn;
 var winston = require('winston');
 
 var writeConf = require('./writeConf').writeConf;
+var defaultConfigFile = require('./writeConf').defaultConfig;
 var writeSkipConf = require('./writeConf').writeSkipConf;
 var writeUI = require('./writeUI').writeUI
 
@@ -11,10 +12,12 @@ var B_WINS = '(B) wins';
 var PLAYER_NOT_FOUND = '[java] Illegal class:';
 var BAD_MAP = '[java] Malformed map file:';
 
-function runGame(map, teamA, teamB, series, replayFolder, noReplays, callback) {
+function runGame(map, teamA, teamB, series, replayFolder, noReplays, callback, configFile) {
+
+    configFile = configFile || defaultConfigFile;
 
     // write the bc.conf file to use the correct map and teams.
-    writeConf(map, teamA, teamB, replayFolder, noReplays);
+    writeConf(map, teamA, teamB, replayFolder, noReplays, configFile);
 
     var round = 0;
     var winner;
@@ -22,7 +25,8 @@ function runGame(map, teamA, teamB, series, replayFolder, noReplays, callback) {
     // after we've written the bc.conf kick off the game!
     var game = spawn('ant',
         [
-            'headless'
+            'headless',
+            '-Dbc.conf=\''+configFile+'\'',
         ]
     );
 

--- a/lib/game.js
+++ b/lib/game.js
@@ -100,7 +100,11 @@ function runReplay(replayFile, callback) {
 
     // after we've written the bc.conf kick off the replay!
     console.log("About to watch " + replayFile);
-    var replay = spawn('ant');
+    var replay = spawn('ant',
+        [
+            '-Dbc.conf=\''+defaultConfigFile+'\'',
+        ]
+    );
 
     replay.stdout.on('data', function (data) {
         data = data.toString();

--- a/lib/game.js
+++ b/lib/game.js
@@ -16,13 +16,13 @@ function runGame(map, teamA, teamB, series, replayFolder, noReplays, callback, c
 
     configFile = configFile || defaultConfigFile;
 
-    // write the bc.conf file to use the correct map and teams.
+    // write the config file to use the correct map and teams.
     writeConf(map, teamA, teamB, replayFolder, noReplays, configFile);
 
     var round = 0;
     var winner;
 
-    // after we've written the bc.conf kick off the game!
+    // after we've written the config kick off the game!
     var game = spawn('ant',
         [
             'headless',
@@ -94,11 +94,11 @@ function runGame(map, teamA, teamB, series, replayFolder, noReplays, callback, c
 
 
 function runReplay(replayFile, callback) {
-    // write the bc.conf file to use the correct map and teams.
+    // write the config file to use the correct map and teams.
     writeSkipConf(true);
     writeUI(replayFile);
 
-    // after we've written the bc.conf kick off the replay!
+    // after we've written the config kick off the replay!
     console.log("About to watch " + replayFile);
     var replay = spawn('ant',
         [

--- a/lib/main.js
+++ b/lib/main.js
@@ -49,7 +49,6 @@ var argv = optimist.boolean(['a', 'b', 'd', 'e', 'g', 'h', 'l', 'm', 'n', 's', '
 var runMatches = require('./runMatches').runMatches;
 var runReplays = require('./watchReplay').runReplays;
 var writeCleanUI = require('./writeUI').writeCleanUI;
-var writeCleanConf = require('./writeConf').writeCleanConf;
 var validate = require('./validate');
 var clearTeams = require('./clearTeams');
 var spawnTeams = require('./spawnTeams');
@@ -159,7 +158,6 @@ function _runMatches() {
 }
 
 function _clean() {
-    writeCleanConf();
     writeCleanUI();
 }
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -16,6 +16,7 @@ var argv = optimist.boolean(['a', 'b', 'd', 'e', 'g', 'h', 'l', 'm', 'n', 's', '
             'm': 'all-maps',
             'n': 'no-replays',
             'o': 'host',
+            'p': 'processes',
             'r': 'replay-dir',
             's': 'series',
             't': 'all-teams',
@@ -34,6 +35,7 @@ var argv = optimist.boolean(['a', 'b', 'd', 'e', 'g', 'h', 'l', 'm', 'n', 's', '
             'm': 'Runs all teams specified on all maps in maps/',
             'n': 'Does not save replays for matches',
             'o': 'Specify a host for the tournament for VsWorld',
+            'p': 'Specify the number of simultaneous processes used to run matches',
             'r': 'Specify the directory to save the replays in',
             's': 'Players play the maps in series instead 1 by 1',
             't': 'Runs all teams in teams/ on the specified maps',
@@ -153,7 +155,7 @@ function _runMatches() {
         _printHelp();
         throw e;
     }
-    runMatches(maps, teams, host, argv.s, argv.r, argv.e, argv.l, argv.x, argv.n, argv.c, argv.d);
+    runMatches(maps, teams, host, argv.s, argv.r, argv.e, argv.l, argv.x, argv.n, argv.c, argv.d, argv.p);
 }
 
 function _clean() {

--- a/lib/runMatches.js
+++ b/lib/runMatches.js
@@ -76,7 +76,10 @@ function mirrorGames(games) {
 }
 
 
-function runMatches(maps, teams, host, series, replayFolder, csv, elo, mirror, noReplays, statsCache, doReport) {
+function runMatches(maps, teams, host, series, replayFolder, csv, elo, mirror, noReplays, statsCache, doReport, numThreads) {
+
+    numThreads = numThreads || 1; // Default to single-threaded
+
     var games, gamesLength;
     if (host) {
         games = _generateVsWorldGames(maps, teams, host, series);
@@ -94,32 +97,6 @@ function runMatches(maps, teams, host, series, replayFolder, csv, elo, mirror, n
 
     var dataCollector = new DataCollector();
 
-    function endGame(round, winner, map, teamA, teamB) {
-        if (!series) {
-            console.log(map, '[' + teamA +'/'+ teamB + ']', winner, round);
-            dataCollector.addGame(map, teamA, teamB, winner, round);
-        }
-        if (statsCache && doReport) {
-            request.post({
-                uri: 'http://' + path.join(statsCache, '/game/'),
-                qs: {
-                    round: round,
-                    winner: winner,
-                    map: map,
-                    teamA: teamA,
-                    teamB: teamB
-                }
-            }, function(error, response, body) {
-                if (error) {
-                    winston.error(error);
-                }
-            })
-        }
-        gamesEnded += 1;
-        startNextGame();
-    }
-
-
     function endMatch() {
         if (gamesEnded === gamesLength) {
             if(host) {
@@ -136,7 +113,7 @@ function runMatches(maps, teams, host, series, replayFolder, csv, elo, mirror, n
     }
 
     var calledEndMatch = false;
-    function startNextGame() {
+    function startNextGame(configFile) {
         if (games.length === 0) {
             if (!calledEndMatch) {
                 calledEndMatch = true;
@@ -184,17 +161,42 @@ function runMatches(maps, teams, host, series, replayFolder, csv, elo, mirror, n
         }
         function computeNextGame() {
             if (series) {
-            var seriesData = dataCollector.startSeries(game[MAP], game[TEAM_A], game[TEAM_B]);
-                runGame(game[MAP], game[TEAM_A], game[TEAM_B], seriesData, replayFolder, noReplays, endGame);
+                var seriesData = dataCollector.startSeries(game[MAP], game[TEAM_A], game[TEAM_B]);
+                runGame(game[MAP], game[TEAM_A], game[TEAM_B], seriesData, replayFolder, noReplays, endGame, configFile);
             } else {
-                runGame(game[MAP], game[TEAM_A], game[TEAM_B], series, replayFolder, noReplays, endGame);
+                runGame(game[MAP], game[TEAM_A], game[TEAM_B], series, replayFolder, noReplays, endGame, configFile);
             }
         }
 
+        function endGame(round, winner, map, teamA, teamB) {
+            if (!series) {
+                console.log(map, '[' + teamA +'/'+ teamB + ']', winner, round);
+                dataCollector.addGame(map, teamA, teamB, winner, round);
+            }
+            if (statsCache && doReport) {
+                request.post({
+                    uri: 'http://' + path.join(statsCache, '/game/'),
+                    qs: {
+                        round: round,
+                        winner: winner,
+                        map: map,
+                        teamA: teamA,
+                        teamB: teamB
+                    }
+                }, function(error, response, body) {
+                    if (error) {
+                        winston.error(error);
+                    }
+                })
+            }
+            gamesEnded += 1;
+            startNextGame(configFile);
+        }
     }
 
     // tried starting multiple games at once but that had weird consequences
-    startNextGame();
+    for (var i = 0; i < numThreads; i++)
+        startNextGame('archonConfig'+i+'.conf');
 }
 
 

--- a/lib/runMatches.js
+++ b/lib/runMatches.js
@@ -9,7 +9,6 @@ var path = require('path');
 var winston = require('winston');
 
 var writeCleanUI = require('./writeUI').writeCleanUI;
-var writeCleanConf = require('./writeConf').writeCleanConf;
 
 
 function _generateRoundRobinGames(maps, teams, series) {
@@ -105,7 +104,6 @@ function runMatches(maps, teams, host, series, replayFolder, csv, elo, mirror, n
             } else {
                 dataCollector.printPlayersSummary(teams);
             }
-            //writeCleanConf();
             //writeCleanUI();
         } else {
             setTimeout(endMatch, 2000);

--- a/lib/watchReplay.js
+++ b/lib/watchReplay.js
@@ -1,7 +1,6 @@
 var fs = require('fs');
 var path = require('path');
 
-var writeCleanConf = require('./writeConf').writeCleanConf;
 var runReplay = require('./game').runReplay
 
 
@@ -46,7 +45,6 @@ function runReplays(replayFoldersOrFiles) {
 
     function _watchReplay() {
         if (replays.length === 0) {
-            writeCleanConf(false);
             return;
         }
         replay = replays.shift();

--- a/lib/writeConf.js
+++ b/lib/writeConf.js
@@ -86,15 +86,16 @@ function _getReplayName(map, teamA, teamB, replayFolder, noReplays) {
     return name;
 }
 
-function writeConf(map, teamA, teamB, replayFolder, noReplays) {
+function writeConf(map, teamA, teamB, replayFolder, noReplays, fileName) {
     var confFileContents = CONF_FILE.join('\n');
+    fileName = fileName || FILE_NAME;
 
     confFileContents += '\n' + MAP_CONF + map;
     confFileContents += '\n' + TEAM_A_CONF + teamA;
     confFileContents += '\n' + TEAM_B_CONF + teamB;
     confFileContents += '\n' + _getReplayName(map, teamA, teamB, replayFolder, noReplays);
 
-    fs.writeFileSync(FILE_NAME, confFileContents);
+    fs.writeFileSync(fileName, confFileContents);
 }
 
 function writeSkipConf(trueFalse) {
@@ -109,6 +110,7 @@ function writeCleanConf() {
 }
 
 module.exports = {
+    defaultConfig: FILE_NAME,
     writeConf: writeConf,
     writeSkipConf: writeSkipConf,
     writeCleanConf: writeCleanConf

--- a/lib/writeConf.js
+++ b/lib/writeConf.js
@@ -27,42 +27,7 @@ var CONF_FILE = [
     'bc.server.transcribe-output=matches\\transcribed.txt',
 ];
 
-var CLEAN_CONF_FILE = [
-    '# Match server settings',
-    'bc.server.throttle=yield',
-    'bc.server.throttle-count=50',
-    '',
-    '# Game engine settings',
-    'bc.engine.debug-methods=false',
-    'bc.engine.silence-a=false',
-    'bc.engine.silence-b=false',
-    'bc.engine.gc=false',
-    'bc.engine.gc-rounds=50',
-    'bc.engine.upkeep=true',
-    'bc.engine.breakpoints=false',
-    'bc.engine.bytecodes-used=true',
-    '',
-    '# Client settings',
-    'bc.client.opengl=false',
-    'bc.client.use-models=true',
-    'bc.client.renderprefs2d=',
-    'bc.client.renderprefs3d=',
-    'bc.client.sound-on=false',
-    'bc.client.check-updates=true',
-    'bc.client.viewer-delay=50',
-    '',
-    '# Headless settings - for "ant file"',
-    'bc.game.maps=adobe',
-    'bc.game.team-a=teleportingplayer',
-    'bc.game.team-b=teleportingplayer',
-    'bc.server.save-file=match.rms',
-    '',
-    '# Transcriber settings',
-    'bc.server.transcribe-input=matches\\match.rms',
-    'bc.server.transcribe-output=matches\\transcribed.txt',
-];
-
-var FILE_NAME = 'bc.conf';
+var FILE_NAME = 'archonConfig.conf';
 var MAP_CONF = 'bc.game.maps=';
 var TEAM_A_CONF = 'bc.game.team-a=';
 var TEAM_B_CONF = 'bc.game.team-b=';
@@ -104,14 +69,8 @@ function writeSkipConf(trueFalse) {
     fs.writeFileSync(FILE_NAME, confFileContents);
 }
 
-function writeCleanConf() {
-    var confFileContents = CLEAN_CONF_FILE.join('\n');
-    fs.writeFileSync(FILE_NAME, confFileContents);
-}
-
 module.exports = {
     defaultConfig: FILE_NAME,
     writeConf: writeConf,
     writeSkipConf: writeSkipConf,
-    writeCleanConf: writeCleanConf
 };


### PR DESCRIPTION
@bovard Code Review
# Problem
#### Summary

There were problems when trying to parallelize matches because each match was reading/writing from the same config file which is re-written for each game, so:
- first thread writes to config file
- first game begins running with specified settings
- second thread re-writes config file
- second game begins running with specified settings
- first game finishes, reads config file to match winning Team (A/B) to teams playing, but config file has changed since it started, and wrong team is reported as winner.
#### Areas of Impact
- Config management
- Match Running
- Replay watching
- General all-around archon functions
# Solution

Each thread now runs with its own dedicated config file which (should) remain undisturbed until the match is run, completed and reported, and then it runs the next game with that file.

Also provided a dedicated default config file (no longer `bc.conf`) so that players are free to manipulate their own default settings without archon changing/overwriting them.  Consequently, I also removed the config cleaner, because archon has a dedicated config file now that shouldn't need to be cleaned.
# How to QA/+10
1. Run matches with -p [numThreads] // --processes [numThreads] flag!  Verify that games and results appear to run as expected.
